### PR TITLE
Docs: update package version to 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add `yaml_front_matter` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:yaml_front_matter, "~> 0.3.0"}]
+  [{:yaml_front_matter, "~> 1.0.0"}]
 end
 ```
 


### PR DESCRIPTION
💁 This change updates the installation instructions for `mix` to use the current generally available version of this package.